### PR TITLE
fix: update plugin dependency checks and notifications, fixes #402

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/database/AutoConfigureDataSourceListener.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/AutoConfigureDataSourceListener.java
@@ -4,6 +4,8 @@ import com.intellij.openapi.project.Project;
 import de.php_perfect.intellij.ddev.DatabaseInfoChangedListener;
 import de.php_perfect.intellij.ddev.cmd.DatabaseInfo;
 import de.php_perfect.intellij.ddev.settings.DdevSettingsState;
+import de.php_perfect.intellij.ddev.util.FeatureRequiredPlugins;
+import de.php_perfect.intellij.ddev.util.PluginChecker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,6 +29,10 @@ public final class AutoConfigureDataSourceListener implements DatabaseInfoChange
         }
 
         if (databaseInfo.type() == null || databaseInfo.version() == null || databaseInfo.name() == null || databaseInfo.username() == null || databaseInfo.password() == null) {
+            return;
+        }
+
+        if (PluginChecker.isMissingRequiredPlugins(this.project, FeatureRequiredPlugins.DATABASE, "database auto-registration")) {
             return;
         }
 

--- a/src/main/java/de/php_perfect/intellij/ddev/node/AutoConfigureNodeInterpreterListener.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/node/AutoConfigureNodeInterpreterListener.java
@@ -6,6 +6,8 @@ import de.php_perfect.intellij.ddev.DescriptionChangedListener;
 import de.php_perfect.intellij.ddev.cmd.Description;
 import de.php_perfect.intellij.ddev.dockerCompose.DdevComposeFileLoader;
 import de.php_perfect.intellij.ddev.settings.DdevSettingsState;
+import de.php_perfect.intellij.ddev.util.FeatureRequiredPlugins;
+import de.php_perfect.intellij.ddev.util.PluginChecker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +32,10 @@ public final class AutoConfigureNodeInterpreterListener implements DescriptionCh
         final VirtualFile composeFile = DdevComposeFileLoader.getInstance(this.project).load();
 
         if (composeFile == null || !composeFile.exists()) {
+            return;
+        }
+
+        if (PluginChecker.isMissingRequiredPlugins(this.project, FeatureRequiredPlugins.NODE_INTERPRETER, "Node.js interpreter auto-registration")) {
             return;
         }
 

--- a/src/main/java/de/php_perfect/intellij/ddev/notification/DdevNotifier.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/notification/DdevNotifier.java
@@ -10,7 +10,9 @@ public interface DdevNotifier {
 
     void notifyAlreadyLatestVersion();
 
-    void notifyMissingPlugin(@NotNull String pluginName);
+    void notifyMissingPlugin(@NotNull String pluginName, @NotNull String featureName);
+
+    void notifyMissingPlugins(@NotNull String pluginNames, @NotNull String featureName);
 
     void notifyPhpInterpreterUpdated(@NotNull String phpVersion);
 

--- a/src/main/java/de/php_perfect/intellij/ddev/notification/DdevNotifierImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/notification/DdevNotifierImpl.java
@@ -58,12 +58,25 @@ public final class DdevNotifierImpl implements DdevNotifier {
     }
 
     @Override
-    public void notifyMissingPlugin(final @NotNull String pluginName) {
+    public void notifyMissingPlugin(final @NotNull String pluginName, final @NotNull String featureName) {
         ApplicationManager.getApplication().invokeLater(() -> NotificationGroupManager.getInstance()
                 .getNotificationGroup(STICKY)
                 .createNotification(
                         DdevIntegrationBundle.message("notification.MissingPlugin.title"),
-                        DdevIntegrationBundle.message("notification.MissingPlugin.text", pluginName),
+                        DdevIntegrationBundle.message("notification.MissingPlugin.withFeature.text", pluginName, featureName),
+                        NotificationType.WARNING
+                )
+                .addAction(new ManagePluginsAction())
+                .notify(this.project), ModalityState.nonModal());
+    }
+
+    @Override
+    public void notifyMissingPlugins(final @NotNull String pluginNames, final @NotNull String featureName) {
+        ApplicationManager.getApplication().invokeLater(() -> NotificationGroupManager.getInstance()
+                .getNotificationGroup(STICKY)
+                .createNotification(
+                        DdevIntegrationBundle.message("notification.MissingPlugins.title"),
+                        DdevIntegrationBundle.message("notification.MissingPlugins.withFeature.text", pluginNames, featureName),
                         NotificationType.WARNING
                 )
                 .addAction(new ManagePluginsAction())

--- a/src/main/java/de/php_perfect/intellij/ddev/php/ConfigurationProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/ConfigurationProviderImpl.java
@@ -1,23 +1,15 @@
 package de.php_perfect.intellij.ddev.php;
 
-import com.intellij.ide.plugins.PluginManager;
-import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.php_perfect.intellij.ddev.cmd.Description;
 import de.php_perfect.intellij.ddev.dockerCompose.DdevComposeFileLoader;
-import de.php_perfect.intellij.ddev.notification.DdevNotifier;
 import de.php_perfect.intellij.ddev.settings.DdevSettingsState;
+import de.php_perfect.intellij.ddev.util.FeatureRequiredPlugins;
+import de.php_perfect.intellij.ddev.util.PluginChecker;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 public final class ConfigurationProviderImpl implements ConfigurationProvider {
-    private static final List<String> REQUIRED_PLUGINS = List.of(
-            "org.jetbrains.plugins.phpstorm-remote-interpreter",
-            "org.jetbrains.plugins.phpstorm-docker",
-            "Docker"
-    );
 
     private final @NotNull Project project;
 
@@ -41,15 +33,8 @@ public final class ConfigurationProviderImpl implements ConfigurationProvider {
             return;
         }
 
-        final var pluginManager = PluginManager.getInstance();
-
-        for (final String id : REQUIRED_PLUGINS) {
-            final PluginId pluginId = PluginId.findId(id);
-
-            if (pluginId == null || pluginManager.findEnabledPlugin(pluginId) == null) {
-                DdevNotifier.getInstance(this.project).notifyMissingPlugin(id);
-                return;
-            }
+        if (PluginChecker.isMissingRequiredPlugins(this.project, FeatureRequiredPlugins.PHP_INTERPRETER, "PHP interpreter auto-registration")) {
+            return;
         }
 
         final DdevInterpreterConfig ddevInterpreterConfig = new DdevInterpreterConfig(description.getName(), "php" + description.getPhpVersion(), composeFile.getPath());

--- a/src/main/java/de/php_perfect/intellij/ddev/settings/DdevSettingsComponent.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/settings/DdevSettingsComponent.java
@@ -1,5 +1,6 @@
 package de.php_perfect.intellij.ddev.settings;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
@@ -8,11 +9,16 @@ import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
 import de.php_perfect.intellij.ddev.DdevIntegrationBundle;
+import de.php_perfect.intellij.ddev.util.FeatureRequiredPlugins;
+import de.php_perfect.intellij.ddev.util.PluginChecker;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.BoxLayout;
 import java.awt.*;
+import java.util.List;
 
 public final class DdevSettingsComponent {
     private final @NotNull JPanel jPanel;
@@ -32,7 +38,7 @@ public final class DdevSettingsComponent {
         checkForUpdatesComment.setForeground(UIManager.getColor("Component.infoForeground"));
         checkForUpdatesComment.setBorder(JBUI.Borders.emptyLeft(24));
         checkForUpdatesPanel.add(checkForUpdatesComment, BorderLayout.CENTER);
-        
+
         JPanel watchDdevPanel = new JPanel(new BorderLayout());
         watchDdevPanel.add(this.watchDdevCheckbox, BorderLayout.NORTH);
         JLabel watchDdevComment = new JLabel(DdevIntegrationBundle.message("settings.watchDdev.description"));
@@ -41,13 +47,35 @@ public final class DdevSettingsComponent {
         watchDdevComment.setBorder(JBUI.Borders.emptyLeft(24));
         watchDdevPanel.add(watchDdevComment, BorderLayout.CENTER);
 
+        // Set up warning indicators and tooltips
+        @NotNull JPanel autoConfigureDataSourcePanel = new JPanel(new BorderLayout());
+        @NotNull JLabel dataSourceWarningLabel = new JLabel(AllIcons.General.Warning);
+        @NotNull JLabel dataSourceWarningText = new JLabel();
+        setupWarningIndicator(autoConfigureDataSourcePanel, this.autoConfigureDataSource, dataSourceWarningLabel,
+                dataSourceWarningText, FeatureRequiredPlugins.DATABASE);
+
+        @NotNull JPanel autoConfigurePhpInterpreterPanel = new JPanel(new BorderLayout());
+        @NotNull JLabel phpWarningLabel = new JLabel(AllIcons.General.Warning);
+        @NotNull JLabel phpWarningText = new JLabel();
+        setupWarningIndicator(autoConfigurePhpInterpreterPanel, this.autoConfigurePhpInterpreter, phpWarningLabel,
+                phpWarningText, FeatureRequiredPlugins.PHP_INTERPRETER);
+
+        @NotNull JPanel autoConfigureNodeJsInterpreterPanel = new JPanel(new BorderLayout());
+        @NotNull JLabel nodeWarningLabel = new JLabel(AllIcons.General.Warning);
+        @NotNull JLabel nodeWarningText = new JLabel();
+        setupWarningIndicator(autoConfigureNodeJsInterpreterPanel, this.autoConfigureNodeJsInterpreter, nodeWarningLabel,
+                nodeWarningText, FeatureRequiredPlugins.NODE_INTERPRETER);
+
         final JPanel panel = new JPanel();
         panel.setBorder(IdeBorderFactory.createTitledBorder(DdevIntegrationBundle.message("settings.automaticConfiguration"), true));
-        panel.setLayout(new GridBagLayout());
-        final GridBagConstraints gc = new GridBagConstraints(0, GridBagConstraints.RELATIVE, 1, 1, 1, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.BOTH, JBUI.emptyInsets(), 0, 0);
-        panel.add(this.autoConfigureDataSource, gc);
-        panel.add(this.autoConfigurePhpInterpreter, gc);
-        panel.add(this.autoConfigureNodeJsInterpreter, gc);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        // Add feature panels with some vertical spacing
+        panel.add(autoConfigureDataSourcePanel);
+        panel.add(Box.createVerticalStrut(5));
+        panel.add(autoConfigurePhpInterpreterPanel);
+        panel.add(Box.createVerticalStrut(5));
+        panel.add(autoConfigureNodeJsInterpreterPanel);
 
         this.ddevBinary.addBrowseFolderListener(
                 project,
@@ -63,6 +91,51 @@ public final class DdevSettingsComponent {
                 .addComponent(panel, 1)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
+    }
+
+    /**
+     * Sets up a warning indicator for a feature that requires plugins.
+     *
+     * @param panel The panel to add the components to
+     * @param checkbox The checkbox for the feature
+     * @param warningLabel The warning icon to show if plugins are missing
+     * @param warningText The label to display the warning text
+     * @param requiredPlugins The list of required plugin IDs
+     */
+    private void setupWarningIndicator(@NotNull JPanel panel, @NotNull JBCheckBox checkbox, @NotNull JLabel warningLabel,
+                                       @NotNull JLabel warningText, @NotNull List<String> requiredPlugins) {
+        // Set up panel with vertical layout
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        // Add checkbox to panel
+        JPanel checkboxPanel = new JPanel(new BorderLayout());
+        checkboxPanel.add(checkbox, BorderLayout.WEST);
+        panel.add(checkboxPanel);
+
+        // Check if any required plugins are missing
+        List<String> missingPlugins = PluginChecker.getMissingPlugins(requiredPlugins);
+
+        if (missingPlugins.isEmpty()) {
+            // No missing plugins, hide warning
+            warningLabel.setVisible(false);
+            warningText.setVisible(false);
+        } else {
+            // Create warning message
+            String warningMessage = DdevIntegrationBundle.message("settings.warning.missingPlugins", String.join(", ", missingPlugins));
+
+            // Set up warning text
+            warningText.setText(" " + warningMessage);
+            warningText.setForeground(UIUtil.getErrorForeground());
+
+            // Create warning panel with left alignment and indentation
+            JPanel warningPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            warningPanel.setBorder(JBUI.Borders.emptyLeft(24));
+            warningPanel.add(warningLabel);
+            warningPanel.add(warningText);
+
+            // Add warning panel below the checkbox
+            panel.add(warningPanel);
+        }
     }
 
     public @NotNull JPanel getPanel() {

--- a/src/main/java/de/php_perfect/intellij/ddev/util/FeatureRequiredPlugins.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/util/FeatureRequiredPlugins.java
@@ -1,0 +1,38 @@
+package de.php_perfect.intellij.ddev.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Utility class to hold the required plugins for each feature.
+ */
+public final class FeatureRequiredPlugins {
+    private FeatureRequiredPlugins() {
+        // Utility class, no instances
+    }
+
+    /**
+     * Required plugins for PHP interpreter auto-registration.
+     */
+    public static final @NotNull List<String> PHP_INTERPRETER = List.of(
+            "com.jetbrains.php",
+            "org.jetbrains.plugins.phpstorm-remote-interpreter",
+            "org.jetbrains.plugins.phpstorm-docker"
+    );
+
+    /**
+     * Required plugins for Node.js interpreter auto-registration.
+     */
+    public static final @NotNull List<String> NODE_INTERPRETER = List.of(
+            "NodeJS",
+            "org.jetbrains.plugins.node-remote-interpreter"
+    );
+
+    /**
+     * Required plugins for database auto-registration.
+     */
+    public static final @NotNull List<String> DATABASE = List.of(
+            "com.intellij.database"
+    );
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/util/PluginChecker.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/util/PluginChecker.java
@@ -1,0 +1,67 @@
+package de.php_perfect.intellij.ddev.util;
+
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.project.Project;
+import de.php_perfect.intellij.ddev.notification.DdevNotifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to check for required plugins.
+ */
+public final class PluginChecker {
+    private PluginChecker() {
+        // Utility class, no instances
+    }
+
+    /**
+     * Checks if any required plugin is missing.
+     * If any plugins are missing, it will notify the user and return true.
+     *
+     * @param project The current project
+     * @param requiredPlugins List of plugin IDs to check
+     * @param featureName The name of the feature that requires these plugins
+     * @return true if any plugin is missing, false if all are available
+     */
+    public static boolean isMissingRequiredPlugins(@NotNull Project project, @NotNull List<String> requiredPlugins, @NotNull String featureName) {
+        List<String> missingPluginNames = getMissingPlugins(requiredPlugins);
+
+        if (!missingPluginNames.isEmpty()) {
+            String missingPluginsDisplay = String.join(", ", missingPluginNames);
+            if (missingPluginNames.size() == 1) {
+                DdevNotifier.getInstance(project).notifyMissingPlugin(missingPluginsDisplay, featureName);
+            } else {
+                DdevNotifier.getInstance(project).notifyMissingPlugins(missingPluginsDisplay, featureName);
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if any required plugin is missing without showing notifications.
+     * This is useful for UI components that want to check dependencies without showing notifications.
+     *
+     * @param requiredPlugins List of plugin IDs to check
+     * @return List of missing plugin display names, empty if all are available
+     */
+    public static @NotNull List<String> getMissingPlugins(@NotNull List<String> requiredPlugins) {
+        final var pluginManager = PluginManager.getInstance();
+        final List<String> missingPluginNames = new ArrayList<>();
+
+        for (final String id : requiredPlugins) {
+            final PluginId pluginId = PluginId.findId(id);
+
+            if (pluginId == null || pluginManager.findEnabledPlugin(pluginId) == null) {
+                String displayName = PluginDisplayNameMapper.getDisplayName(id);
+                missingPluginNames.add(displayName);
+            }
+        }
+
+        return missingPluginNames;
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/util/PluginDisplayNameMapper.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/util/PluginDisplayNameMapper.java
@@ -1,0 +1,53 @@
+package de.php_perfect.intellij.ddev.util;
+
+import de.php_perfect.intellij.ddev.DdevIntegrationBundle;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class to map plugin IDs to display names.
+ */
+public final class PluginDisplayNameMapper {
+    private static final Map<String, String> PLUGIN_DISPLAY_NAMES = new HashMap<>();
+
+    static {
+        // Initialize with known plugin IDs and their message bundle keys
+        PLUGIN_DISPLAY_NAMES.put("com.jetbrains.php", "plugin.name.php");
+        PLUGIN_DISPLAY_NAMES.put("org.jetbrains.plugins.phpstorm-remote-interpreter", "plugin.name.phpstorm-remote-interpreter");
+        PLUGIN_DISPLAY_NAMES.put("org.jetbrains.plugins.phpstorm-docker", "plugin.name.phpstorm-docker");
+        PLUGIN_DISPLAY_NAMES.put("Docker", "plugin.name.docker");
+        PLUGIN_DISPLAY_NAMES.put("NodeJS", "plugin.name.nodejs");
+        PLUGIN_DISPLAY_NAMES.put("org.jetbrains.plugins.node-remote-interpreter", "plugin.name.node-remote-interpreter");
+        PLUGIN_DISPLAY_NAMES.put("com.intellij.database", "plugin.name.database");
+        PLUGIN_DISPLAY_NAMES.put("org.jetbrains.plugins.terminal", "plugin.name.terminal");
+    }
+
+    private PluginDisplayNameMapper() {
+        // Utility class, no instances
+    }
+
+    /**
+     * Get the display name for a plugin ID.
+     * First tries to get a localized name from the message bundle.
+     * If not found, returns the plugin ID.
+     *
+     * @param pluginId The plugin ID
+     * @return The display name
+     */
+    public static @NotNull String getDisplayName(@NotNull String pluginId) {
+        // First try to get a localized name from our message bundle
+        if (PLUGIN_DISPLAY_NAMES.containsKey(pluginId)) {
+            String messageKey = PLUGIN_DISPLAY_NAMES.get(pluginId);
+            String localizedName = DdevIntegrationBundle.message(messageKey);
+
+            if (!localizedName.equals(messageKey)) {
+                return localizedName;
+            }
+        }
+
+        // Fall back to plugin ID if we couldn't find a label
+        return pluginId;
+    }
+}

--- a/src/main/resources/META-INF/DdevIntegration-withDocker.xml
+++ b/src/main/resources/META-INF/DdevIntegration-withDocker.xml
@@ -1,6 +1,4 @@
 <idea-plugin>
-    <depends>Docker</depends>
-
     <extensions defaultExtensionNs="com.intellij">
         <applicationService
                 serviceImplementation="de.php_perfect.intellij.ddev.dockerCompose.DockerComposeCredentialProviderImpl"

--- a/src/main/resources/META-INF/DdevIntegration-withNodeRemoteInterpreter.xml
+++ b/src/main/resources/META-INF/DdevIntegration-withNodeRemoteInterpreter.xml
@@ -1,6 +1,5 @@
 <idea-plugin>
-    <depends>NodeJS</depends>
-    <depends>org.jetbrains.plugins.phpstorm-docker</depends>
+    <depends>org.jetbrains.plugins.node-remote-interpreter</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="de.php_perfect.intellij.ddev.node.NodeInterpreterProviderImpl"

--- a/src/main/resources/META-INF/DdevIntegration-withPhp.xml
+++ b/src/main/resources/META-INF/DdevIntegration-withPhp.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
-    <depends>com.jetbrains.php</depends>
+    <depends>org.jetbrains.plugins.phpstorm-remote-interpreter</depends>
     <depends>org.jetbrains.plugins.phpstorm-docker</depends>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,15 +22,18 @@
 
     <idea-version since-build="232.8660.185" until-build="241.*"/>
     <depends>com.intellij.modules.platform</depends>
+    <!-- Required dependencies -->
+    <depends>intellij.platform.ijent.impl</depends> <!-- Remote Execution Agent -->
+    <depends config-file="DdevIntegration-withDocker.xml">Docker</depends>
+
+    <!-- Optional dependencies -->
     <depends config-file="DdevIntegration-withTerminal.xml" optional="true">org.jetbrains.plugins.terminal</depends>
     <depends config-file="DdevIntegration-withDatabase.xml" optional="true">com.intellij.database</depends>
-    <depends config-file="DdevIntegration-withDocker.xml" optional="true">org.jetbrains.plugins.phpstorm-docker
-    </depends>
     <depends config-file="DdevIntegration-withPhp.xml" optional="true">
-        org.jetbrains.plugins.phpstorm-remote-interpreter
+        com.jetbrains.php
     </depends>
     <depends config-file="DdevIntegration-withNodeRemoteInterpreter.xml" optional="true">
-        org.jetbrains.plugins.node-remote-interpreter
+        NodeJS
     </depends>
 
     <resource-bundle>messages.DdevIntegrationBundle</resource-bundle>

--- a/src/main/resources/messages/DdevIntegrationBundle.properties
+++ b/src/main/resources/messages/DdevIntegrationBundle.properties
@@ -68,7 +68,9 @@ notification.InstallDdev.text=Install DDEV to run this project.
 notification.NewVersionAvailable.title=DDEV update available
 notification.NewVersionAvailable.text=Your DDEV version {0} is outdated. Update to {1} now.
 notification.MissingPlugin.title=Missing plugin
-notification.MissingPlugin.text=You must enable the {0} plugin to use the PHP interpreter auto-registration.
+notification.MissingPlugin.withFeature.text=You must enable the {0} plugin to use the {1} feature.
+notification.MissingPlugins.title=Missing plugins
+notification.MissingPlugins.withFeature.text=You must enable the following plugins to use the {1} feature: {0}
 notification.InterpreterUpdated.title=DDEV PHP interpreter updated
 notification.InterpreterUpdated.text=The PHP binary {0} is now used for the DDEV remote interpreter.
 notification.UnknownStateEntered.title=DDEV integration entered unknown state
@@ -115,3 +117,16 @@ errorReporting.submit=Report to Author
 errorReporting.taskTitle=Sending error report
 errorReporting.success.title=Thank you!
 errorReporting.success.text=Your error report has been submitted. Please refer to this ID in discussions: {0} If there is anything else you would like to add, please open a GitHub issue.
+
+# Plugin Names
+plugin.name.php=PHP
+plugin.name.phpstorm-remote-interpreter=PHP Remote Interpreter
+plugin.name.phpstorm-docker=PHP Docker
+plugin.name.docker=Docker
+plugin.name.nodejs=Node.js
+plugin.name.node-remote-interpreter=Node.js Remote Interpreter
+plugin.name.database=Database Tools and SQL
+plugin.name.terminal=Terminal
+
+# Settings warnings
+settings.warning.missingPlugins=Missing plugins: {0}

--- a/src/test/java/de/php_perfect/intellij/ddev/notification/DdevNotifierTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/notification/DdevNotifierTest.java
@@ -73,7 +73,7 @@ final class DdevNotifierTest extends BasePlatformTestCase {
         Notification[] notifications = notificationManager.getNotificationsOfType(Notification.class, project);
         assertEmpty(notifications);
 
-        new DdevNotifierImpl(project).notifyMissingPlugin("Some Plugin");
+        new DdevNotifierImpl(project).notifyMissingPlugin("Some Plugin", "Test Feature");
 
         this.waitForEventQueue();
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #402 

## How this PR Solves the Problem:

Completely reworked the dependency checks, and how they're being presented.

- Required Plugin dependencies:
  - Remote Execution Agent (intellij.platform.ijent.impl)
  - Docker
- Optional Plugin dependencies:
  - Terminal (plugin.name.terminal)
- Dependencies for PHP auto-configure:
  - PHP (com.jetbrains.php)
  - PHP Docker (org.jetbrains.plugins.phpstorm-remote-interpreter)
  - PHP Remote Interpreter (org.jetbrains.plugins.phpstorm-docker)
- Dependencies for node.js auto-configure:
  - Node.js (NodeJS)
  - Node.js Remote Interpreter (org.jetbrains.plugins.node-remote-interpreter)
- Dependencies for database auto-configure:
  - Database Tools and SQL (com.intellij.database)

## Manual Testing Instructions:

Install [ddev-intellij-plugin-0.0.1-dev.zip](https://github.com/user-attachments/files/19985565/ddev-intellij-plugin-0.0.1-dev.zip)

Disable different combinations of required and optional plugins, and verify that the DDEV plugin notifies about the missing ones correctly.

Examples:
- Enabling DDEV when Docker is disabled:
![image](https://github.com/user-attachments/assets/da5c0fc6-dbe2-4f20-a3c8-2ffd78c73cde)
- Node.js Remote Interpreter is disabled:
![image](https://github.com/user-attachments/assets/a978c7bf-2253-4cf3-b51c-666755c5fb77)
- PHP Docker & PHP Remote Interpreter are disabled:
![image](https://github.com/user-attachments/assets/2f6d4dfa-c653-4bca-bb24-71028ba08743)

Warnings about missing dependencies are now also displayed in the DDEV settings panel:
![image](https://github.com/user-attachments/assets/ca9ef058-d3d6-4e74-96cd-af0d3da25cff)

## Related Issue Link(s):
