### PR TITLE
feat: update version detection to support ddev head version

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/version/Version.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/version/Version.java
@@ -1,23 +1,63 @@
 package de.php_perfect.intellij.ddev.version;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class Version implements Comparable<Version> {
 
     public final int @NotNull [] numbers;
 
-
     public final @NotNull String string;
+
+    /**
+     * The build information for head versions (e.g., "36-ge74e3a95f" in "v1.24.4-36-ge74e3a95f")
+     * Will be null for regular release versions
+     */
+    @Nullable
+    private final String buildInfo;
+
+    /**
+     * Pattern to match head versions like "v1.24.4-36-ge74e3a95f"
+     * Group 1: The semantic version part (v1.24.4)
+     * Group 2: The build info part (36-ge74e3a95f)
+     */
+    private static final Pattern HEAD_VERSION_PATTERN = Pattern.compile("^(v?\\d+(?:\\.\\d+)?(?:\\.\\d+)?)-(\\d+-g[a-f0-9]+)$");
 
     public Version(@NotNull String version) {
         this.string = version;
-        final String[] split = version.replaceAll("^v", "").split("-")[0].split("\\.");
+
+        // Check if this is a head version
+        Matcher headVersionMatcher = HEAD_VERSION_PATTERN.matcher(version);
+        String versionForParsing;
+
+        if (headVersionMatcher.matches()) {
+            // This is a head version, use the semantic version part for parsing
+            versionForParsing = headVersionMatcher.group(1);
+            this.buildInfo = headVersionMatcher.group(2);
+        } else {
+            // Regular version handling
+            versionForParsing = version.split("-")[0];
+            this.buildInfo = null;
+        }
+
+        final String[] split = versionForParsing.replaceAll("^v", "").split("\\.");
         numbers = new int[split.length];
         for (int i = 0; i < split.length; i++) {
             numbers[i] = Integer.parseInt(split[i]);
         }
+    }
+
+    public boolean isHeadVersion() {
+        return buildInfo != null;
+    }
+
+    @Nullable
+    public String getBuildInfo() {
+        return buildInfo;
     }
 
     @Override

--- a/src/test/java/de/php_perfect/intellij/ddev/cmd/DdevImplTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/cmd/DdevImplTest.java
@@ -39,6 +39,20 @@ final class DdevImplTest extends BasePlatformTestCase {
     }
 
     @Test
+    void headVersion() throws CommandFailedException {
+        final Version expected = new Version("v1.24.4-36-ge74e3a95f");
+        final ProcessOutput processOutput = new ProcessOutput("ddev version v1.24.4-36-ge74e3a95f", "", 0, false, false);
+
+        final MockProcessExecutor mockProcessExecutor = (MockProcessExecutor) ApplicationManager.getApplication().getService(ProcessExecutor.class);
+        mockProcessExecutor.addProcessOutput("ddev --version", processOutput);
+
+        Version actual = new DdevImpl().version("ddev", getProject());
+        Assertions.assertEquals(expected, actual);
+        Assertions.assertTrue(actual.isHeadVersion());
+        Assertions.assertEquals("36-ge74e3a95f", actual.getBuildInfo());
+    }
+
+    @Test
     void detailedVersions() throws CommandFailedException, IOException {
         Versions expected = new Versions("v1.19.0", "20.10.12", "v2.2.2", "docker-desktop");
 

--- a/src/test/java/de/php_perfect/intellij/ddev/version/VersionTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/version/VersionTest.java
@@ -15,6 +15,32 @@ final class VersionTest {
     }
 
     @Test
+    void headVersionIsParsedCorrectly() {
+        final Version version = new Version("v1.24.4-36-ge74e3a95f");
+
+        Assertions.assertArrayEquals(new int[]{1, 24, 4}, version.numbers);
+        Assertions.assertTrue(version.isHeadVersion());
+        Assertions.assertEquals("36-ge74e3a95f", version.getBuildInfo());
+        Assertions.assertEquals("v1.24.4-36-ge74e3a95f", version.toString());
+    }
+
+    @Test
+    void regularVersionIsNotHeadVersion() {
+        final Version version = new Version("v1.24.4");
+
+        Assertions.assertFalse(version.isHeadVersion());
+        Assertions.assertNull(version.getBuildInfo());
+    }
+
+    @Test
+    void debugVersionIsNotHeadVersion() {
+        final Version version = new Version("v1.24.4-DEBUG");
+
+        Assertions.assertFalse(version.isHeadVersion());
+        Assertions.assertNull(version.getBuildInfo());
+    }
+
+    @Test
     void compareTo_withEarlierVersion_isGreaterThan() {
         Assertions.assertEquals(1, new Version("2.0.0").compareTo(new Version("1.0.0")));
     }
@@ -42,5 +68,16 @@ final class VersionTest {
     @Test
     void compareTo_withMorePreciseLaterVersion_isLessThan() {
         Assertions.assertEquals(-1, new Version("1").compareTo(new Version("1.0.1")));
+    }
+
+    @Test
+    void compareTo_headVersionWithSameBaseVersion_isEqual() {
+        Assertions.assertEquals(0, new Version("v1.24.4").compareTo(new Version("v1.24.4-36-ge74e3a95f")));
+    }
+
+    @Test
+    void compareTo_headVersionWithDifferentBaseVersion_isUnequal() {
+        Assertions.assertEquals(-1, new Version("v1.24.3-42-gabcdef12").compareTo(new Version("v1.24.4")));
+        Assertions.assertEquals(1, new Version("v1.24.5-42-gabcdef12").compareTo(new Version("v1.24.4")));
     }
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

Currently, ddev head versions that report a version like `ddev version v1.24.4-36-ge74e3a95f` are not supported by the plugin.

## How this PR Solves the Problem:

Updated the version parsing to handle head versions.

## Manual Testing Instructions:

Download a DDEV head version: https://ddev.readthedocs.io/en/stable/developers/building-contributing/#testing-latest-commits-on-head
Change the DDEV settings in PhpStorm to use the head version path (/usr/local/bin/ddev)
Check if the plugin still works

## Related Issue Link(s):
