### PR TITLE
feat: add experimental ddev executor for composer

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerExecution.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerExecution.java
@@ -1,0 +1,126 @@
+package de.php_perfect.intellij.ddev.php.composer;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.project.Project;
+import com.jetbrains.php.composer.execution.ComposerExecution;
+import de.php_perfect.intellij.ddev.cmd.Description;
+import de.php_perfect.intellij.ddev.state.DdevStateManager;
+import de.php_perfect.intellij.ddev.state.State;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * DDEV-specific implementation of ComposerExecution that runs Composer commands through DDEV.
+ */
+public class DdevComposerExecution implements ComposerExecution {
+    private static final String ROOT_TAG_NAME = "ddev";
+
+    public DdevComposerExecution() {
+        // No configuration needed for DDEV composer
+    }
+
+    @Override
+    @NotNull
+    public ProcessHandler createProcessHandler(@NotNull Project project, String workingDir, @NotNull List<String> command, @NotNull String commandText) throws ExecutionException {
+        // Build the DDEV command: ddev composer [args...]
+        GeneralCommandLine commandLine = new GeneralCommandLine();
+        commandLine.setExePath("ddev");
+        commandLine.addParameter("composer");
+        commandLine.addParameters(command);
+        commandLine.setWorkDirectory(workingDir != null ? workingDir : project.getBasePath());
+
+        try {
+            return new DdevComposerProcessHandler(commandLine.createProcess(), commandText);
+        } catch (Exception e) {
+            throw new ExecutionException("Failed to start DDEV Composer process: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void cancelProcess(@NotNull ProcessHandler handler) {
+        handler.destroyProcess();
+    }
+
+    @Override
+    public boolean isWellConfigured(@NotNull Project project, boolean checkComposer) {
+        return getValidationMessage(project) == null;
+    }
+
+    @Nullable
+    public String getValidationMessage(@NotNull Project project) {
+        // Check if DDEV is available and project is configured
+        try {
+            State state = DdevStateManager.getInstance(project).getState();
+            if (!state.isBinaryConfigured()) {
+                return "DDEV binary is not configured";
+            }
+
+            // Check if project is configured
+            if (!state.isConfigured()) {
+                return "DDEV project is not configured";
+            }
+
+            // Check if DDEV is running - this prevents auto-starting DDEV
+            // when executing Composer commands
+            Description description = state.getDescription();
+            if (description == null || description.getStatus() != Description.Status.RUNNING) {
+                return "DDEV is not running. Please start DDEV before using Composer commands.";
+            }
+
+            return null;
+        } catch (Exception e) {
+            return "Failed to validate DDEV configuration: " + e.getMessage();
+        }
+    }
+
+    @Override
+    @Nullable
+    public String getInterpreterId() {
+        // DDEV composer doesn't use a specific interpreter ID
+        return null;
+    }
+
+    @NotNull
+    public Element save() {
+        Element element = new Element(ROOT_TAG_NAME);
+        // Add a type attribute to help with identification during loading
+        element.setAttribute("type", "ddev");
+        return element;
+    }
+
+    @Nullable
+    public static DdevComposerExecution load(@NotNull Element element) {
+        if (!ROOT_TAG_NAME.equals(element.getName())) {
+            return null;
+        }
+
+        // Verify the type attribute if present
+        String type = element.getAttributeValue("type");
+        if (type != null && !"ddev".equals(type)) {
+            return null;
+        }
+
+        return new DdevComposerExecution();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "DdevComposerExecution{}";
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerExecutionProvider.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerExecutionProvider.java
@@ -1,0 +1,41 @@
+package de.php_perfect.intellij.ddev.php.composer;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.jetbrains.php.composer.execution.ComposerExecution;
+import com.jetbrains.php.composer.execution.ComposerExecutionProvider;
+import de.php_perfect.intellij.ddev.DdevIntegrationBundle;
+import org.jdom.Element;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides DDEV-based Composer execution for projects using DDEV.
+ */
+public class DdevComposerExecutionProvider implements ComposerExecutionProvider {
+
+    @Nls
+    @NotNull
+    @Override
+    public String getPresentableName() {
+        return DdevIntegrationBundle.message("composer.execution.provider.ddev.name");
+    }
+
+    @Override
+    public boolean isMyExecution(@NotNull ComposerExecution execution) {
+        return execution instanceof DdevComposerExecution;
+    }
+
+    @NotNull
+    @Override
+    public Form createForm(@NotNull Project project, @NotNull Disposable disposable) {
+        return new DdevComposerForm(project, disposable);
+    }
+
+    @Nullable
+    @Override
+    public DdevComposerExecution loadExecution(@NotNull Element element) {
+        return DdevComposerExecution.load(element);
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerForm.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerForm.java
@@ -1,0 +1,79 @@
+package de.php_perfect.intellij.ddev.php.composer;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.FormBuilder;
+import com.jetbrains.php.composer.execution.ComposerExecution;
+import com.jetbrains.php.composer.execution.ComposerExecutionProvider;
+import de.php_perfect.intellij.ddev.DdevIntegrationBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Configuration form for DDEV Composer execution.
+ */
+public class DdevComposerForm implements ComposerExecutionProvider.Form {
+    private final JPanel myMainPanel;
+    private DdevComposerExecution myExecution;
+
+    @SuppressWarnings({"unused", "UnusedParameters"}) // Parameters required by ComposerExecutionProvider interface
+    public DdevComposerForm(@NotNull Project project, @NotNull Disposable disposable) {
+        myExecution = new DdevComposerExecution();
+        myMainPanel = createUIComponents();
+    }
+
+    private JPanel createUIComponents() {
+        JBLabel descriptionLabel = new JBLabel(DdevIntegrationBundle.message("composer.form.ddev.description"));
+        descriptionLabel.setFont(descriptionLabel.getFont().deriveFont(Font.ITALIC));
+
+        return FormBuilder.createFormBuilder()
+                .addComponent(descriptionLabel)
+                .getPanel();
+    }
+
+    @NotNull
+    @Override
+    public JComponent getComponent() {
+        return myMainPanel;
+    }
+
+    @Nullable
+    @Override
+    public ValidationInfo validate() {
+        // No validation needed for DDEV composer
+        return null;
+    }
+
+    @Override
+    public boolean reset(@NotNull ComposerExecution execution) {
+        if (execution instanceof DdevComposerExecution ddevExecution) {
+            myExecution = ddevExecution;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void apply() {
+        // No additional configuration needed for DDEV
+    }
+
+
+
+    @NotNull
+    @Override
+    public ComposerExecution getExecution() {
+        return myExecution;
+    }
+
+    @Override
+    public boolean isModified(@NotNull ComposerExecution execution) {
+        // Check if the current execution is different from the form's execution
+        return !(execution instanceof DdevComposerExecution) || !myExecution.equals(execution);
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerProcessHandler.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/composer/DdevComposerProcessHandler.java
@@ -1,0 +1,18 @@
+package de.php_perfect.intellij.ddev.php.composer;
+
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessTerminatedListener;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.Charset;
+
+/**
+ * Process handler for DDEV Composer commands.
+ */
+public class DdevComposerProcessHandler extends OSProcessHandler {
+    
+    public DdevComposerProcessHandler(@NotNull Process process, @NotNull String commandLine) {
+        super(process, commandLine, Charset.defaultCharset());
+        ProcessTerminatedListener.attach(this);
+    }
+}

--- a/src/main/resources/META-INF/DdevIntegration-withPhp.xml
+++ b/src/main/resources/META-INF/DdevIntegration-withPhp.xml
@@ -12,6 +12,10 @@
         <ddevConfigArgumentProvider implementation="de.php_perfect.intellij.ddev.php.PhpVersionArgumentProvider"/>
     </extensions>
 
+    <extensions defaultExtensionNs="com.jetbrains.php">
+        <composer.execProvider implementation="de.php_perfect.intellij.ddev.php.composer.DdevComposerExecutionProvider"/>
+    </extensions>
+
     <projectListeners>
         <listener class="de.php_perfect.intellij.ddev.php.server.ConfigureServerListener"
                   topic="de.php_perfect.intellij.ddev.DescriptionChangedListener"/>

--- a/src/main/resources/messages/DdevIntegrationBundle.properties
+++ b/src/main/resources/messages/DdevIntegrationBundle.properties
@@ -111,6 +111,9 @@ tutorial.status.link=How to use
 tutorial.terminal.title=Open DDEV terminal
 tutorial.terminal.text=Open a terminal directly in your DDEV web container
 tutorial.terminal.link=How to use
+# Composer
+composer.execution.provider.ddev.name=DDEV
+composer.form.ddev.description=Run Composer commands through DDEV (ddev composer)
 # Error reporting
 errorReporting.privacyNotice=I agree to my software configuration, product information and the error details shown above being used by the developers of the DDEV Integration Plugin to let them improve their product and to provide you with support service. The reported exception data are not expected to contain any personal data.
 errorReporting.submit=Report to Author


### PR DESCRIPTION
## The Problem/Issue/Bug:
The docker compose remote interpreter for IntelliJ automatically starts the docker services, which hinders regular DDEV use. Additionally, use the regular PHP calls, we're initializing unwanted debugging connections with every call to composer.

## How this PR Solves the Problem:
Adding a dedicated DDEV executor to the composer setting circumvents the issue, since we can prevent unwanted calls to docker compose, and instead use ddev composer for running the composer commands. Which also solves the issue of xDebug sessions being started on all composer interactions.

## Manual Testing Instructions:

## Related Issue Link(s):
#441 